### PR TITLE
Add workflow to build generate documentation website

### DIFF
--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -19,7 +19,10 @@ jobs:
         run: .github/workflows/scripts/get_dependencies.sh cmake doxygen sphinx
 
       - name: Build Python documentation
-        run: sphinx-apidoc -f -o docs/source/python_api/ reference_data
+        run: |
+          . venv/bin/activate
+          sphinx-apidoc -f -o docs/source/python_api/ reference_data
+          deactivate
 
       - name: Build C++ and overall documentation
         run: .github/workflows/scripts/build_docs.sh chemcache_cxx_api


### PR DESCRIPTION
## Status

- [x] Ready to go

## Description

Sets up CI to build the ChemCache documentation. Closes #17 and closes #18.

## TODOs and/or Questions

- [x] Set up workflow based on [LibChemist `deploy_docs.yaml`](https://github.com/NWChemEx-Project/LibChemist/blob/master/.github/workflows/deploy_docs.yaml)
- [x] Add Python documentation build step
- [x] Workflow is successful in a dry run on my local machine