### PR TITLE
Include STO-family basis sets

### DIFF
--- a/reference_data/scrape_bse.py
+++ b/reference_data/scrape_bse.py
@@ -397,7 +397,7 @@ def main(args: argparse.Namespace) -> None:
     print("---")
 
     # Add metadata value filters at this point
-    scraper.add_filter("family", ["pople", "dunning"])
+    scraper.add_filter("family", ["pople", "dunning", "sto"])
 
     for name in scraper.filtered_basis_sets:
         clean_name, text = scraper.download_basis_set(name)


### PR DESCRIPTION
This is a very small PR adding the STO-family basis sets to be downloaded from BSE and added to the ChemCache reference data.