### PR TITLE
Add auxiliary density fit Dunning basis sets

### DIFF
--- a/reference_data/scrape_bse.py
+++ b/reference_data/scrape_bse.py
@@ -397,7 +397,8 @@ def main(args: argparse.Namespace) -> None:
     print("---")
 
     # Add metadata value filters at this point
-    scraper.add_filter("family", ["pople", "dunning", "sto"])
+    scraper.add_filter(
+        "family", ["pople", "dunning", "dunning_fit", "dunning_pp_fit", "sto"])
 
     for name in scraper.filtered_basis_sets:
         clean_name, text = scraper.download_basis_set(name)


### PR DESCRIPTION
As the title says, this adds auxiliary basis sets for density fitting from the Dunning basis set family to the basis set list to be downloaded from the Basis Set Exchange. This PR is r2g.