### PR TITLE
Force 'generated_data' branch to be overwritten by 'master'

### DIFF
--- a/.github/workflows/download_and_generate_data.yaml
+++ b/.github/workflows/download_and_generate_data.yaml
@@ -28,7 +28,7 @@ jobs:
           . venv/bin/activate
           pip install -r reference_data/requirements.txt
 
-      - name: Merge master -> generated_data
+      - name: Overwrite 'generated_data' with 'master'
         run: |
           git fetch
           git checkout --track origin/generated_data


### PR DESCRIPTION
## Brief Description

This is yet another attempt to fix the GitHub Action that updates `generated_data` with new changes in `master`, then regenerates all of the chemical data code.

**Note:** Due to possible permissions differences between my fork and the main repository, this may not work once deployed. (but I sure hope it does)

## Detailed Description

There are a lot of ways that merge conflicts can pop up in our `generated_data` branch, as we are finding out by the GitHub Action to merge `master` into `generated_data` continually failing. There is an extra data generation step that occurs after the merge that mostly downloads new data files and generates new code files. These new files do not cause any merge issues, since these files do not exist in `master`. However, a few files, like `src/chemcache/load_basis_sets.cpp`, are overwritten with new information about the aforementioned new code files. Now, if the original versions of those files in `master` are changed, there will be a merge conflict with `generated_data`.

We do not care about the previous data when new changes from `master` are merged in, so it makes sense to just overwrite `generated_data` with `master` every time. I could not find a GitHub Action that would do this, so I figured it out myself. From my local and fork repo testing, this process seems to work.

## Checklist

- [x] Added git commands must work in a freshly cloned, local copy of the repository.
- [x] The modified workflow must work with the existing state of `generate_data` in NWChemEx/ChemCache.
- [x] The modified workflow must pass for my fork of ChemCache.
