### PR TITLE
Format generated C++ code as part of CI

### DIFF
--- a/.github/workflows/download_and_generate_data.yaml
+++ b/.github/workflows/download_and_generate_data.yaml
@@ -49,5 +49,5 @@ jobs:
       - name: Commit and push changes to data branch
         uses: github-actions-x/commit@v2.9
         with:
-          branch: generated_data
-          message: Automatically updated reference data using GitHub Actions
+          push-branch: generated_data
+          commit-message: Automatically updated reference data using GitHub Actions


### PR DESCRIPTION
Closes #34. Formats the generated C++ code so it conforms to `clang-format` styling defined in the `.clang-format` file as part of the CI. The formatting occurs right before the generated code is committed.

The formatting step added here succeeded in my fork. However, the "Commit and push changes to data branch" step is failing due to a `fatal: unsafe repository ('/github/workspace' is owned by someone else)` error.