### PR TITLE
Clear Warning in `generated_data`

### DIFF
--- a/utils/data_management/generate_basis.py
+++ b/utils/data_management/generate_basis.py
@@ -422,7 +422,7 @@ def _parse_bases_nw(basis_set_filepaths: list, sym2Z: dict,
                     # Indicate that we are in a basis block and should parse
                     basis_block = True
                     is_pure = (bstart_match['shelltype'] == "SPHERICAL")
-        
+
         # Did we get anything out of the file?
         if not tmp_basis:
             print("no basis information parsed")

--- a/utils/data_management/generate_basis.py
+++ b/utils/data_management/generate_basis.py
@@ -422,6 +422,12 @@ def _parse_bases_nw(basis_set_filepaths: list, sym2Z: dict,
                     # Indicate that we are in a basis block and should parse
                     basis_block = True
                     is_pure = (bstart_match['shelltype'] == "SPHERICAL")
+        
+        # Did we get anythin out of the file?
+        if not tmp_basis:
+            print("no basis information parsed")
+            sys.stdout.flush()
+            continue
 
         # Process the data read from the file
         bases[basis_set] = {}

--- a/utils/data_management/generate_basis.py
+++ b/utils/data_management/generate_basis.py
@@ -423,7 +423,7 @@ def _parse_bases_nw(basis_set_filepaths: list, sym2Z: dict,
                     basis_block = True
                     is_pure = (bstart_match['shelltype'] == "SPHERICAL")
         
-        # Did we get anythin out of the file?
+        # Did we get anything out of the file?
         if not tmp_basis:
             print("no basis information parsed")
             sys.stdout.flush()


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #79

**Description**
The warning from #79 comes from the fact that no basis set information is actually found in `def2-ecp.nw` and the ECP specification isn't parsed by our current routine. Given that we don't support ECPs at the moment, that's probably fine. The fix here is in the `generate_basis.py` file, where there is an added check that skips the generation of a source file for a basis set file where no information was parsed.
